### PR TITLE
State clearly where the boundaries are btwn photutils and imageutils

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,13 @@ imageutils
 Image processing utilities for Astropy.
 
 * Code: https://github.com/astropy/imageutils
-* Docs: https://imageutils.readthedocs.org/
+* Docs: https://imageutils.readthedocs.org/en/latest/imageutils/index.html
+
+The docs contain a
+`What is this? <https://imageutils.readthedocs.org/en/latest/imageutils/index.html#what-is-this>`__
+and a 
+`Related Astropy packages <https://imageutils.readthedocs.org/en/latest/imageutils/index.html#related-astropy-packages>`__
+section that explain the scope and purpose of this package.
 
 Status reports for developers
 -----------------------------

--- a/docs/imageutils/index.rst
+++ b/docs/imageutils/index.rst
@@ -13,11 +13,8 @@ What is this?
 This is an attempt to collect image processing utilities that are generally considered
 useful for astronomers and propose to include them as ``astropy.image`` into the
 Astropy core package in fall 2014 (before the Astropy 1.0 release).
-
 The need for this became clear when Astropy affiliated packages started to re-implement
-common image processing functions like resampling or cutouts over and over.
-Note that there is a separate repo for `reproject` functionality
-and there's the `astropy.convolution` sub-package that's already in the core.
+common image processing functions like resampling or cutouts.
 
 The philosophy here should be to use `numpy`,
 `scipy.ndimage` and `skimage` as much as possible instead of re-implementing basic
@@ -29,5 +26,18 @@ Contributions welcome!
 (please start by filing an `issue on Github <https://github.com/astropy/imageutils/issues>`__ asking if
 some functionality is in scope for this package before spending time on a pull request)
 
+Related Astropy packages
+------------------------
+
+* The `astropy.convolution` and `astropy.wcs` sub-packages in the Astropy core.
+* The `reproject` package which is planned to be moved into Astropy core as `astropy.reproject`.
+  It only contains reprojection routines that use `WCS` ... image resampling methods
+  that don't use WCS info belong in this `imageutils` package.
+* The `photutils <http://photutils.readthedocs.org/en/latest/photutils/index.html>`__ affiliated
+  package contains methods for source detection and photometry.
+
+How to structure Astropy into sub-packages and which function belongs where is sometimes not
+easy to decide. Please ask on Github or on the Astropy mailing list if you would like to contribute
+something and don't know where to put it, or if you think something is really out of place and should be moved.
 
 .. automodapi:: imageutils


### PR DESCRIPTION
This is probably most easily places in the `README` of one or both of the projects, but should be somewhere quite apparent: a statement somewhere of what belongs in photutils vs imageutils. I imagine there is a fair amount of "grey zone", but right now all it says is "Image processing utilities" vs. "image photometry tools".

cc @cdeil
